### PR TITLE
Feature/flow when done promise

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ import { BufferSlice } from './src/core/buffer';
 import { BufferProperties } from './src/core/buffer-props';
 import { CommonMimeTypes, MimetypePrefix, PayloadDescriptor, PayloadDetails } from './src/core/payload-description';
 import { Signal } from './src/core/signal';
-import { Flow } from './src/core/flow';
+import { Flow, FlowErrorType, FlowEvent, FlowState } from './src/core/flow';
 
 import { WebFileChooserSocket } from './src/io-sockets/web-file-chooser.socket';
 import { HTML5MediaSourceBufferSocket } from './src/io-sockets/html5-media-source-buffer.socket';
@@ -73,7 +73,7 @@ export const Core = {
   PayloadDescriptor,
   PayloadDetails,
   Signal,
-  Flow
+  Flow, FlowErrorType, FlowEvent, FlowState
 }
 
 export const Processors = {

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -1,0 +1,23 @@
+export type ErrorInfo = {
+  code: number,
+  message: string,
+  nestedError?: Error,
+  customData?: any,
+};
+
+/**
+ * Caution: This does shallow clone. May matter if you have custom data.
+ * In case you want that actually copied, take care of it yourself
+ * @param errorInfo
+ */
+export function cloneErrorInfo(errorInfo: ErrorInfo): ErrorInfo {
+  return Object.assign({}, errorInfo)
+}
+
+/**
+ * Uses `cloneErrorInfo` applied to an existing object of a type extending (i.e overlaping completely with) `ErrorInfo`.
+ * @param errorInfo
+ */
+export function assignErrorInfo<E extends ErrorInfo>(errorInfoOut: E, errorInfoIn: ErrorInfo): ErrorInfo {
+  return Object.assign(errorInfoOut, errorInfoIn)
+}

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -1,27 +1,48 @@
 import { Processor } from './processor';
 import { Socket } from './socket';
+import { ErrorInfo } from './error';
+import { VoidCallback } from '../common-types';
 
 export enum FlowState {
-  VOID = 'void',
-  WAITING = 'waiting',
-  FLOWING = 'flowing'
+  VOID = 'void', // the initial state
+  WAITING = 'waiting', // there must be one packet arrived at each terminating external output
+                       // socket to reach this state, and then no more data gets transferred
+  FLOWING = 'flowing', // this is when data is freely flowing through all procs
+  COMPLETED = 'completed' // this is when all external input socket data is consumed
+                          // or otherwise not available anymore, and the last EOS has reached the terminating output sockets
 }
 
-/*
-export enum FlowEvent {
-
+export enum FlowCompletionResult {
+  NONE = 'none',
+  OK = 'ok',
+  FAILED = 'failed'
 }
-*/
+
+export enum FlowErrorType {
+  CORE = 'core',
+  PROC = 'proc',
+  RUNTIME = 'runtime'
+}
+
+export type FlowError = ErrorInfo & {
+  type: FlowErrorType
+}
 
 export type FlowStateChangeCallback = (previousState: FlowState, newState: FlowState) => void;
 
-// TODO: create generic set class in objec-ts
+// TODO: create generic Set class in objec-ts
 export abstract class Flow {
 
   constructor (
     public onStateChangePerformed: FlowStateChangeCallback,
     public onStateChangeAborted: (reason: string) => void
-  ) {}
+  ) {
+
+    this._whenDone = new Promise((resolve, reject) => {
+      this._whenDoneResolve = resolve;
+      this._whenDoneReject = reject;
+    });
+  }
 
   private _state: FlowState = FlowState.VOID;
   private _pendingState: FlowState | null = null;
@@ -29,6 +50,11 @@ export abstract class Flow {
 
   private _processors: Set<Processor> = new Set();
   private _extSockets: Set<Socket> = new Set();
+
+  private _whenDone: Promise<FlowCompletionResult>;
+  private _whenDoneResolve: (value: FlowCompletionResult) => void = null;
+  private _whenDoneReject: (reason: FlowError) => void = null;
+  private _completionResult: FlowCompletionResult = FlowCompletionResult.NONE;
 
   add (...p: Processor[]) {
     p.forEach((proc) => {
@@ -44,6 +70,10 @@ export abstract class Flow {
     });
   }
 
+  whenCompleted(): Promise<FlowCompletionResult> {
+    return this._whenDone;
+  }
+
   get procList (): Processor[] {
     return Array.from(this._processors);
   }
@@ -52,15 +82,60 @@ export abstract class Flow {
     return Array.from(this.getExternalSockets());
   }
 
-  set state (newState: FlowState) {
+  getCurrentState(): FlowState {
+    return this._state;
+  }
+
+  getPendingState (): FlowState | null {
+    return this._pendingState;
+  }
+
+  getPreviousState (): FlowState | null {
+    return this._prevState;
+  }
+
+  abortPendingStateChange (reason: string) {
+    this.onStateChangeAborted_(reason);
+    this._pendingState = null;
+    this.onStateChangeAborted(reason);
+  }
+
+  getExternalSockets (): Set<Socket> {
+    return this._extSockets;
+  }
+
+  getCompletionResult(): FlowCompletionResult {
+    return this._completionResult;
+  }
+
+  protected setCompleted(completionResult: FlowCompletionResult, error: FlowError = null) {
+    this._completionResult = completionResult;
+    // enforce state change to completed
+    this.state = FlowState.COMPLETED;
+    switch(completionResult) {
+    case FlowCompletionResult.NONE:
+      throw new Error('Can not complete with no result');
+    case FlowCompletionResult.OK:
+      this._whenDoneResolve(completionResult);
+      break;
+    case FlowCompletionResult.FAILED:
+      this._whenDoneReject(error);
+      break;
+    }
+  }
+
+  protected set state (newState: FlowState) {
     if (this._pendingState) {
       throw new Error('Flow state-change still pending: ' + this._pendingState);
     }
 
-    const cb: FlowStateChangeCallback = this.onStateChangePerformed_.bind(this);
+    const cb: VoidCallback = this.onStateChangePerformed_.bind(this, this._state, newState);
 
     const currentState = this._state;
     switch (currentState) {
+    case FlowState.COMPLETED:
+      this.onCompleted_(cb);
+      break;
     case FlowState.VOID:
       if (newState !== FlowState.WAITING) {
         fail();
@@ -92,38 +167,25 @@ export abstract class Flow {
     }
   }
 
-  get state (): FlowState {
+  // more of a convenience since the setter exists but can't be public therefore
+  // (Typescript wants accessors to agree in visibility)
+  protected get state (): FlowState {
     return this._state;
   }
 
-  getPendingState (): FlowState | null {
-    return this._pendingState;
-  }
-
-  getPreviousState (): FlowState | null {
-    return this._prevState;
-  }
-
-  abortPendingStateChange (reason: string) {
-    this.onStateChangeAborted_(reason);
-    this._pendingState = null;
-    this.onStateChangeAborted(reason);
-  }
-
-  getExternalSockets (): Set<Socket> {
-    return this._extSockets;
-  }
-
-  private onStateChangePerformed_ (newState) {
-    this._prevState = this._state;
+  private onStateChangePerformed_ (previousState: FlowState, newState: FlowState) {
+    this._prevState = previousState;
     this._state = newState;
     this._pendingState = null;
     this.onStateChangePerformed(this._prevState, this._state);
   }
 
-  protected abstract onVoidToWaiting_(cb: FlowStateChangeCallback);
-  protected abstract onWaitingToVoid_(cb: FlowStateChangeCallback);
-  protected abstract onWaitingToFlowing_(cb: FlowStateChangeCallback);
-  protected abstract onFlowingToWaiting_(cb: FlowStateChangeCallback);
+  protected abstract onVoidToWaiting_(done: VoidCallback);
+  protected abstract onWaitingToVoid_(done: VoidCallback);
+  protected abstract onWaitingToFlowing_(done: VoidCallback);
+  protected abstract onFlowingToWaiting_(done: VoidCallback);
+  protected abstract onCompleted_(done: VoidCallback);
+
   protected abstract onStateChangeAborted_(reason: string);
+
 }

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -140,6 +140,11 @@ export abstract class Flow extends EventEmitter<FlowEvent> {
       throw new Error('Flow state-change still pending: ' + this._pendingState);
     }
 
+    if (newState === FlowState.COMPLETED
+      && this._completionResult === FlowCompletionResult.NONE) {
+        throw new Error('state change to COMPLETED has to be triggered by setCompleted');
+      }
+
     this.emit(FlowEvent.STATE_CHANGE_PENDING);
 
     const cb: VoidCallback = this.onStateChangePerformed_.bind(this, this._state, newState);

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'eventemitter3';
 import { ProcessorTask } from './processor-task';
 import { getLogger } from '../logger';
 import { EnvironmentVars } from './env';
+import { ErrorInfo } from './error';
 
 const {debug, error} = getLogger("Processor");
 
@@ -20,15 +21,13 @@ export enum ProcessorEvent {
 }
 
 export enum ProcessorErrorCode {
-    GENERIC = 0
+    GENERIC = 0,
+    BAD_FORMAT = 1
 }
 
-export type ProcessorError = {
+export type ProcessorError = ErrorInfo & {
     processor: Processor,
     code: ProcessorErrorCode
-    message: string
-    nestedError?: Error,
-    customData?: any,
 }
 
 export type ProcessorEventDataProps = Partial<{


### PR DESCRIPTION
Introduces a "completed" state on the `Flow` structure, as well as errors and a promise accessor to handle completion conveniently. Also, we introduce a bad-format error on procs.

Proc implemenations should trigger an error events, which should be caught and translated eventually to flow errors.

Flow implementations can set the state to completed and