### PR TITLE
Publish npm package on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 language: node_js
 node_js:
-  - "8.10.0"
+  - 11
+script:
+  # - npm run lint
+  - make
+deploy:
+  - provider: npm
+    skip_cleanup: true
+    email: stephan@emliri.com
+    tag: latest
+    on:
+      repo: emliri/multimedia-js
+      tags: true
+    api_key: $NPM_API_KEY

--- a/package.json
+++ b/package.json
@@ -15,6 +15,14 @@
   "repository": "github.com/tchakabam/multimedia.js.git",
   "author": "Stephan Hesse <tchakabam@gmail.com>, <stephan@emliri.com>",
   "license": "LGPL, Copyright (c) 2016, 2017, 2018 Stephan Hesse, Emliri",
+  "public": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "vendor/ffmpeg.js"
+  ],
   "dependencies": {
     "bootstrap": "^4.1.3",
     "bowser": "^1.9.4",


### PR DESCRIPTION
This commit allows automatically building and publishing to npm every time a new tag is pushed to GitHub.

If Travis CI is not yet configured with the project, merge this pr first, log in at https://travis-ci.org/ and enable this repo.


npm publish requires a token set up on Travis CI:
-  Log in to your NPM account, and generate a new token at https://www.npmjs.com/settings/USER/tokens, where USER is the name of the user account which is capable of publishing the npm package.
- Go to https://travis-ci.org/emliri/multimedia-js/settings
- Create a new environment variable named `NPM_API_KEY` and set the value to the previously created NPM key


Once Travis is set up I recommend the following workflow:
- Make changes and push commits
- Once ready to release a new version, run `npm version patch` or `npm version minor` or `npm version major`, depending on which version you want to increment. Check `npm help version` for more options.
- Push to GitHub with `git push origin master --tags` and see Travis running the build and publishing to NPM.

Note: this workflow assumes every change happens on master.