### PR TITLE
Flow: Concatenate mp4 videos to multiple chunk/coding-sequence/sample-descriptor tracks (no retranscode)

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,6 +4,10 @@
 
 # Bugs
 
+- Logging mask in workers
+
+- XHR 404 error propagation in concat use-cases or others
+
 - Clone PayloadDetails when cloning BufferProps (and also add clone method to underlying PayloadDescription)
 
 - Move TS-demuxer to worker-proxy mode

--- a/TODO
+++ b/TODO
@@ -4,6 +4,8 @@
 
 # Bugs
 
+- Something horrible happens with CPU when error thrown inside Packet.prototype.forEachBufferSlice
+
 - Logging mask in workers
 
 - XHR 404 error propagation in concat use-cases or others

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "multimedia",
   "version": "1.0.0",
   "description": "Multimedia streaming framework for browser and node",
-  "main": "index.js",
+  "main": "index.ts",
   "scripts": {
     "build": "ts-node ./node_modules/.bin/webpack --progress",
     "build:watch": "npm run build -- --watch",

--- a/src/common-utils.ts
+++ b/src/common-utils.ts
@@ -83,11 +83,12 @@ export function copyArrayBuffer (
   src: ArrayBuffer, dest: ArrayBuffer,
   length: number = src.byteLength,
   srcOffset: number = 0, destOffset: number = 0) {
-  if (srcOffset + length >= src.byteLength) {
+
+  if (srcOffset + length > src.byteLength) {
     throw new Error(`Source buffer is too small for copy target of ${length} bytes at offset ${srcOffset}`);
   }
 
-  if (destOffset + length >= dest.byteLength) {
+  if (destOffset + length > dest.byteLength) {
     throw new Error(`Destination buffer is too small for copy target of ${length} bytes to offset at ${destOffset}`);
   }
 
@@ -157,8 +158,8 @@ export function concatArrayBuffers (buffer1: ArrayBuffer, buffer2: ArrayBuffer):
  */
 export function concatTypedArraySlice(typedArray1: ArrayBufferView, typedArray2: ArrayBufferView): ArrayBuffer {
   const newBuffer = new ArrayBuffer(typedArray1.byteLength + typedArray2.byteLength);
-  copyArrayBuffer(typedArray1.buffer, newBuffer, typedArray1.byteOffset, typedArray1.byteLength, 0);
-  copyArrayBuffer(typedArray2.buffer, newBuffer, typedArray2.byteOffset, typedArray2.byteLength, typedArray1.byteLength);
+  copyArrayBuffer(typedArray1.buffer, newBuffer, typedArray1.byteLength, typedArray1.byteOffset, 0);
+  copyArrayBuffer(typedArray2.buffer, newBuffer, typedArray2.byteLength, typedArray2.byteOffset, typedArray1.byteLength);
   return newBuffer;
 }
 

--- a/src/common-utils.ts
+++ b/src/common-utils.ts
@@ -97,10 +97,23 @@ export function copyArrayBuffer (
 }
 
 /**
+ * Iterate over copyArrayBuffer with array of ArrayBuffer as input, offset on each pass is shifted so
+ * that the buffers content are concatenated in the destination. If destination size is too low
+ * `copyArrayBuffer` (i.e this function) will throw an error.
+ * @param src
+ * @param dest
+ */
+export function copyArrayBuffers(src: ArrayBuffer[], dest: ArrayBuffer) {
+  for (let i = 0; i < src.length; i++) {
+    copyArrayBuffer(src[i], dest, src[i].byteLength, 0, i === 0 ? 0 : src[i - 1].byteLength);
+  }
+}
+
+/**
  * Copies all data from one buffer into a new one, optionnally with offset and size arguments
  * @param buffer
- * @param begin
- * @param end
+ * @param offset
+ * @param size
  */
 export function copyToNewArrayBuffer (buffer: ArrayBuffer, offset: number = 0, size?: number): ArrayBuffer {
   if (offset >= buffer.byteLength || offset + size > buffer.byteLength) {

--- a/src/common-utils.ts
+++ b/src/common-utils.ts
@@ -60,8 +60,8 @@ export function flattenOneDeepNestedArray<T> (a: OneDeepNestedArray<T>): T[] {
   return [].concat(...a);
 }
 
-export function unsafeFlattenAnyNestedArray<T> (arr: any[]): T[] {
-  return arr.reduce(function (flat, toFlatten) {
+export function unsafeFlattenAnyNestedArray<T> (array: any[]): T[] {
+  return array.reduce(function (flat, toFlatten) {
     return flat.concat(Array.isArray(toFlatten) ? unsafeFlattenAnyNestedArray(toFlatten) : toFlatten);
   }, []);
 }

--- a/src/common-utils.ts
+++ b/src/common-utils.ts
@@ -132,14 +132,6 @@ export function copyArrayBufferCollection (abs: ArrayBuffer[]) {
 }
 
 /**
- * Copies only the window that the view points to into a new buffer
- * @param typedArray
- */
-export function allocAndCopyTypedArraySlice (typedArray: ArrayBufferView): ArrayBuffer {
-  return copyToNewArrayBuffer(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
-}
-
-/**
  * Concatenates two existing buffers into a newly allocated third one
  * @param buffer1
  * @param buffer2
@@ -155,6 +147,28 @@ export function concatArrayBuffers (buffer1: ArrayBuffer, buffer2: ArrayBuffer):
   view.set(new Uint8Array(buffer1), 0);
   view.set(new Uint8Array(buffer2), buffer1.byteLength);
   return newBuffer;
+}
+
+/**
+ * Concatenate the data slices from two ArrayBufferView objects
+ * @param typedArray1
+ * @param typedArray2
+ * @returns A new ArrayBuffer containing the concatenated data from both view windows in the specific order
+ */
+export function concatTypedArraySlice(typedArray1: ArrayBufferView, typedArray2: ArrayBufferView): ArrayBuffer {
+  const newBuffer = new ArrayBuffer(typedArray1.byteLength + typedArray2.byteLength);
+  copyArrayBuffer(typedArray1.buffer, newBuffer, typedArray1.byteOffset, typedArray1.byteLength, 0);
+  copyArrayBuffer(typedArray2.buffer, newBuffer, typedArray2.byteOffset, typedArray2.byteLength, typedArray1.byteLength);
+  return newBuffer;
+}
+
+/**
+ * Copies only the window that the view points to into a new buffer
+ * @param typedArray
+ * @returns A newly allocated ArrayBuffer
+ */
+export function copyTypedArraySlice (typedArray: ArrayBufferView): ArrayBuffer {
+  return copyToNewArrayBuffer(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
 }
 
 export function concatArrays<T> (arg0: T[], ...args: T[][]): T[] {

--- a/src/core/buffer.ts
+++ b/src/core/buffer.ts
@@ -172,6 +172,27 @@ export class BufferSlice {
     }
 
     /**
+     * Appends the buffer data to this object s data and returns a new BufferSlice.
+     * @param buffer
+     * @param props
+     * @returns new BufferSlice
+     */
+    append (buffer: BufferSlice, props?: BufferProperties): BufferSlice {
+      const newBuffer = concatTypedArraySlice(this.getDataView(), buffer.getDataView());
+      return new BufferSlice(newBuffer, 0, newBuffer.byteLength, props);
+    }
+
+    /**
+     * Inverse of `append` method. Prepends the buffer data to this object s data and returns a new BufferSlice.
+     * @param buffer
+     * @param props
+     * @returns new BufferSlice
+     */
+    prepend(buffer: BufferSlice, props?: BufferProperties): BufferSlice {
+      return buffer.append(this, props);
+    }
+
+    /**
      * Copies the actual underlying data and creates a new slice with the same properties.
      *
      * @see BufferSlice.copy (static method)

--- a/src/core/buffer.ts
+++ b/src/core/buffer.ts
@@ -1,4 +1,4 @@
-import { allocAndCopyTypedArraySlice, copyToNewArrayBuffer } from '../common-utils';
+import { copyToNewArrayBuffer, copyTypedArraySlice, concatTypedArraySlice } from '../common-utils';
 import { BufferProperties } from './buffer-props';
 
 /**
@@ -242,7 +242,7 @@ export class BufferSlice {
      * allocates a new ArrayBuffer from the current slice
      */
     newArrayBuffer (): ArrayBuffer {
-      return allocAndCopyTypedArraySlice(this.getDataView());
+      return copyTypedArraySlice(this.getDataView());
     }
 
     toString (): string {

--- a/src/core/fifo.ts
+++ b/src/core/fifo.ts
@@ -1,8 +1,8 @@
 import { Packet } from './packet';
-import { InputSocket, SocketDescriptor } from './socket';
+import { InputSocket, SocketDescriptor, OutputSocket } from './socket';
 import { VoidCallback } from '../common-types';
 
-export class Fifo extends InputSocket {
+export class FifoQueue extends InputSocket {
   private _packets: Packet[] = [];
 
   constructor (
@@ -22,7 +22,22 @@ export class Fifo extends InputSocket {
     if (this._packets.length === 0) {
       return null;
     }
+    return this._packets.shift();
+  }
+
+  dequeue(): Packet {
+    if (this._packets.length === 0) {
+      return null;
+    }
     return this._packets.pop();
+  }
+
+  drop() {
+    this._packets = [];
+  }
+
+  get length(): number {
+    return this._packets.length;
   }
 
   private _onReceive (p: Packet): boolean {
@@ -35,3 +50,37 @@ export class Fifo extends InputSocket {
     this._onPacketWasQueued();
   }
 }
+
+export class FifoValve extends OutputSocket {
+
+  constructor(
+    private _queue: FifoQueue,
+    sd: SocketDescriptor
+  ) {
+    super(sd);
+  }
+
+  get queue() { return this._queue; }
+
+  passOne() {
+    this.transfer(this._queue.pop());
+  }
+
+  drain() {
+    while(this._queue.length) {
+      this.passOne();
+    }
+  }
+}
+
+export function wrapOutputSocketWithValve(
+  output: OutputSocket,
+  onPacketWasQueued: VoidCallback = () => {}): FifoValve {
+
+  const q = new FifoQueue(onPacketWasQueued)
+  output.connect(q)
+
+  return new FifoValve(q, output.descriptor())
+}
+
+

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -49,8 +49,8 @@ export type FlowStateChangeCallback = (previousState: FlowState, newState: FlowS
 // TODO: create generic Set class in objec-ts
 export abstract class Flow extends EventEmitter<FlowEvent> {
   constructor (
-    public onStateChangePerformed: FlowStateChangeCallback,
-    public onStateChangeAborted: (reason: string) => void
+    public onStateChangePerformed: FlowStateChangeCallback = () => {},
+    public onStateChangeAborted: (reason: string) => void = () => {}
   ) {
     super();
 

--- a/src/core/packet.ts
+++ b/src/core/packet.ts
@@ -298,9 +298,4 @@ export class Packet {
     return description;
   }
 
-  /*
-  isPayloadInfoConsistent(): boolean {
-    throw new Error('not implemented');
-  }
-  */
 }

--- a/src/core/payload-description.ts
+++ b/src/core/payload-description.ts
@@ -225,6 +225,8 @@ export class PayloadDetails {
   // place to put generic codec init-data // TODO: get rid of number[] here
   codecConfigurationData: Uint8Array | number[] = null
 
+  codecProfile: number = NaN;
+
   // video
   width: number = 0;
   height: number = 0;

--- a/src/core/processor-proxy.worker.ts
+++ b/src/core/processor-proxy.worker.ts
@@ -12,6 +12,8 @@ import { makeUUID_v1 } from '../common-crypto';
 import { getLogger, LoggerLevel } from '../logger';
 
 import { Processors } from '../../index';
+// FIXME: import this importScripts so that logger categories can apply to self config
+// AND collect the config from localStorage at worker init (on SPAWN message)
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts

--- a/src/core/socket.ts
+++ b/src/core/socket.ts
@@ -16,6 +16,7 @@ export enum SocketType {
 }
 
 export enum SocketEvent {
+  ANY_PACKET_TRANSFERED = 'packet-transfered',
   ANY_PACKET_RECEIVED = 'any-packet-received',
   DATA_PACKET_RECEIVED = 'data-packet-received', // "non-symbolic"
   EOS_PACKET_RECEIVED = 'eos-packet-received'
@@ -223,6 +224,7 @@ export abstract class Socket extends EventEmitter<SocketEvent> implements Signal
       dispatchAsyncTask(() => {
         try {
           resolve(this.transferSync(p));
+          super.emit(SocketEvent.ANY_PACKET_TRANSFERED);
         } catch (e) {
           error('Error upon packet-transfer execution:', e);
           reject(e);
@@ -280,7 +282,7 @@ export abstract class Socket extends EventEmitter<SocketEvent> implements Signal
     return this.owner;
   }
 
-  emit (e: SocketEvent, ...args: any[]): boolean {
+  emit (e: SocketEvent): boolean {
     throw new Error('Illegal call');
   }
 

--- a/src/core/socket.ts
+++ b/src/core/socket.ts
@@ -16,7 +16,7 @@ export enum SocketType {
 }
 
 export enum SocketEvent {
-  ANY_PACKET_TRANSFERED = 'packet-transfered',
+  ANY_PACKET_TRANSFERRED = 'any-packet-transferred',
   ANY_PACKET_RECEIVED = 'any-packet-received',
   DATA_PACKET_RECEIVED = 'data-packet-received', // "non-symbolic"
   EOS_PACKET_RECEIVED = 'eos-packet-received'
@@ -224,7 +224,7 @@ export abstract class Socket extends EventEmitter<SocketEvent> implements Signal
       dispatchAsyncTask(() => {
         try {
           resolve(this.transferSync(p));
-          super.emit(SocketEvent.ANY_PACKET_TRANSFERED);
+          super.emit(SocketEvent.ANY_PACKET_TRANSFERRED);
         } catch (e) {
           error('Error upon packet-transfer execution:', e);
           reject(e);
@@ -325,7 +325,7 @@ export class InputSocket extends Socket {
   transferSync (p: Packet): boolean {
     this.setTransferring_(true);
     const b = this.onReceive_(p);
-    this._onTransfer(p);
+    this._onTransferred(p);
     this.setTransferring_(false);
     return b;
   }
@@ -341,7 +341,7 @@ export class InputSocket extends Socket {
     ]);
   }
 
-  private _onTransfer (p: Packet) {
+  private _onTransferred (p: Packet) {
     this._emit(SocketEvent.ANY_PACKET_RECEIVED);
     if (p.isSymbolic()) {
       switch (p.symbol) {

--- a/src/flows/combine-mp4s-to-mov.flow.ts
+++ b/src/flows/combine-mp4s-to-mov.flow.ts
@@ -35,14 +35,7 @@ export class CombineMp4sToMovFlow extends Flow {
     private _downloadLinkContainer: HTMLElement = null,
     private _isMp3Audio: boolean = false
   ) {
-    super(
-      (prevState, newState) => {
-        console.log('previous state:', prevState, 'new state:', newState);
-      },
-      (reason) => {
-        console.log('state change aborted. reason:', reason);
-      }
-    );
+    super();
   }
 
   private _setup () {
@@ -58,7 +51,7 @@ export class CombineMp4sToMovFlow extends Flow {
         log('using ffmpeg.js bin path:', EnvironmentVars.FFMPEG_BIN_PATH);
 
         ffmpegAacTranscodeProc = newProcessorWorkerShell(
-          unsafeProcessorType(FFmpegConvertProcessor),
+          unsafeProcessorType(FFmpegConvertProcessor), // WHY ?
           [audioConfig, null],
           [EnvironmentVars.FFMPEG_BIN_PATH]
         );
@@ -95,7 +88,9 @@ export class CombineMp4sToMovFlow extends Flow {
 
       // hook up transcoding stage
       let mp4AudioOutSocket = xhrSocketAudioFile;
+
       if (ffmpegAacTranscodeProc) {
+        
         xhrSocketAudioFile.connect(ffmpegAacTranscodeProc.in[0]);
         mp4AudioOutSocket = ffmpegAacTranscodeProc.out[0];
       }

--- a/src/flows/combine-mp4s-to-mov.flow.ts
+++ b/src/flows/combine-mp4s-to-mov.flow.ts
@@ -1,10 +1,10 @@
-import { Flow, FlowStateChangeCallback, FlowCompletionResult, FlowState, FlowCompletionResultCode } from '../core/flow';
+import { Flow, FlowCompletionResultCode } from '../core/flow';
 import { XhrSocket } from '../io-sockets/xhr.socket';
 import { MP4DemuxProcessor } from '../processors/mp4-demux.processor';
 import { H264ParseProcessor } from '../processors/h264-parse.processor';
 import { MP4MuxProcessor } from '../processors/mp4-mux-mozilla.processor';
 import { ProcessorEvent, ProcessorEventData } from '../core/processor';
-import { OutputSocket, SocketEvent } from '../core/socket';
+import { OutputSocket } from '../core/socket';
 import { MP3ParseProcessor } from '../processors/mp3-parse.processor';
 import { WebFileDownloadSocket } from '../io-sockets/web-file-download.socket';
 import { newProcessorWorkerShell, unsafeProcessorType } from '../core/processor-factory';
@@ -90,7 +90,7 @@ export class CombineMp4sToMovFlow extends Flow {
       let mp4AudioOutSocket = xhrSocketAudioFile;
 
       if (ffmpegAacTranscodeProc) {
-        
+
         xhrSocketAudioFile.connect(ffmpegAacTranscodeProc.in[0]);
         mp4AudioOutSocket = ffmpegAacTranscodeProc.out[0];
       }

--- a/src/flows/concat-mp4s.flow.ts
+++ b/src/flows/concat-mp4s.flow.ts
@@ -1,37 +1,99 @@
 import { Flow } from "../core/flow";
 import { VoidCallback } from "../common-types";
+import { XhrSocket } from "../io-sockets/xhr.socket";
+import { newProcessorWorkerShell } from "../core/processor-factory";
+import { MP4DemuxProcessor } from "../processors/mp4-demux.processor";
+import { ProcessorEvent, ProcessorEventData } from "../core/processor";
+import { OutputSocket, SocketEvent } from "../core/socket";
+import { FifoValve, wrapOutputSocketWithValve } from "../core/fifo";
+import { getLogger, LoggerLevel } from "../logger";
+import { PayloadDescriptor } from "../core/payload-description";
 
+const { log } = getLogger("ConcatMp4sFlow", LoggerLevel.ON, true);
 
 export class ConcatMp4sFlow extends Flow {
 
+    /**
+     *
+     * @param _movUrlA First file URL
+     * @param _movUrlB Second file URL
+     * @param _allowReencode defaults to true. when true will re-encode to Bs tracks to As respective audio/video configurations
+     * @param _toggleConcatOrder defaults to false. if true will toggle order of concatenation (B before A, but not changing re-encode behavior of course)
+     */
     constructor(
-        private _videoUrlA: string,
-        private _videoUrlB:  string
+        private _movUrlA: string,
+        private _movUrlB:  string,
+        private _allowReencode: boolean = true,
+        private _toggleConcatOrder: boolean = false
     ) {
         super();
     }
 
-    protected onVoidToWaiting_(done: VoidCallback) {
-        throw new Error("Method not implemented.");
+    private _setup() {
+
+      const xhrSocketMovA = new XhrSocket(this._movUrlA);
+      const xhrSocketMovB = new XhrSocket(this._movUrlB);
+
+      let fifoVideoA: FifoValve = null;
+      let fifoAudioA: FifoValve = null;
+      let payloadDescrVideoA: PayloadDescriptor = null;
+      let payloadDescrAudioA: PayloadDescriptor = null;
+
+      const mp4Demux = newProcessorWorkerShell(MP4DemuxProcessor);
+
+      mp4Demux.on(ProcessorEvent.OUTPUT_SOCKET_CREATED, (data: ProcessorEventData) => {
+
+        if (data.socket.payload().isVideo()) {
+
+          fifoVideoA = wrapOutputSocketWithValve(OutputSocket.fromUnsafe(data.socket), () => {});
+
+          data.socket.on(SocketEvent.ANY_PACKET_TRANSFERED, () => {
+            if (!payloadDescrVideoA) {
+              payloadDescrVideoA = fifoVideoA.queue.peek().defaultPayloadInfo;
+              log('got primary video payload description:', payloadDescrVideoA)
+            }
+          });
+
+        } else if (data.socket.payload().isAudio()) {
+
+          fifoAudioA = wrapOutputSocketWithValve(OutputSocket.fromUnsafe(data.socket), () => {});
+
+          data.socket.on(SocketEvent.ANY_PACKET_TRANSFERED, () => {
+            if (!payloadDescrAudioA) {
+              payloadDescrAudioA = fifoAudioA.queue.peek().defaultPayloadInfo;
+              log('got primary audio payload description:', payloadDescrVideoA)
+            }
+          });
+
+        }
+
+      });
+
+      xhrSocketMovA.connect(mp4Demux.in[0])
     }
-    
+
+    protected onVoidToWaiting_(done: VoidCallback) {
+      done()
+    }
+
     protected onWaitingToVoid_(done: VoidCallback) {
-        throw new Error("Method not implemented.");
+      done()
     }
 
     protected onWaitingToFlowing_(done: VoidCallback) {
-        throw new Error("Method not implemented.");
+      done()
+      this._setup()
     }
 
     protected onFlowingToWaiting_(done: VoidCallback) {
-        throw new Error("Method not implemented.");
+      done()
     }
 
     protected onCompleted_(done: VoidCallback) {
-        throw new Error("Method not implemented.");
+      done()
     }
 
     protected onStateChangeAborted_(reason: string) {
-        throw new Error("Method not implemented.");
+      //
     }
 }

--- a/src/flows/concat-mp4s.flow.ts
+++ b/src/flows/concat-mp4s.flow.ts
@@ -1,0 +1,37 @@
+import { Flow } from "../core/flow";
+import { VoidCallback } from "../common-types";
+
+
+export class ConcatMp4sFlow extends Flow {
+
+    constructor(
+        private _videoUrlA: string,
+        private _videoUrlB:  string
+    ) {
+        super();
+    }
+
+    protected onVoidToWaiting_(done: VoidCallback) {
+        throw new Error("Method not implemented.");
+    }
+    
+    protected onWaitingToVoid_(done: VoidCallback) {
+        throw new Error("Method not implemented.");
+    }
+
+    protected onWaitingToFlowing_(done: VoidCallback) {
+        throw new Error("Method not implemented.");
+    }
+
+    protected onFlowingToWaiting_(done: VoidCallback) {
+        throw new Error("Method not implemented.");
+    }
+
+    protected onCompleted_(done: VoidCallback) {
+        throw new Error("Method not implemented.");
+    }
+
+    protected onStateChangeAborted_(reason: string) {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/flows/concat-mp4s.flow.ts
+++ b/src/flows/concat-mp4s.flow.ts
@@ -8,9 +8,6 @@ import { OutputSocket, SocketEvent, InputSocket, Socket } from "../core/socket";
 import { FifoValve, wrapOutputSocketWithValve } from "../core/fifo";
 import { getLogger, LoggerLevel } from "../logger";
 import { PayloadDescriptor } from "../core/payload-description";
-import { FFmpegConversionTargetInfo } from "../processors/ffmpeg/ffmpeg-tool";
-import { EnvironmentVars } from "../core/env";
-import { FFmpegConvertProcessor } from "../processors/ffmpeg-convert.processor";
 import { MP4MuxProcessor } from "../processors/mp4-mux-mozilla.processor";
 import { PacketSymbol } from "../core/packet";
 import { WebFileDownloadSocket } from "../io-sockets/web-file-download.socket";
@@ -21,7 +18,6 @@ const { log } = getLogger("ConcatMp4sFlow", LoggerLevel.ON, true);
 export class ConcatMp4sFlow extends Flow {
 
     /**
-     *
      * @param _movUrlA First file URL
      * @param _movUrlB Second file URL
      * @param _allowReencode defaults to true. when true will re-encode to Bs tracks to As respective audio/video configurations

--- a/src/flows/concat-mp4s.flow.ts
+++ b/src/flows/concat-mp4s.flow.ts
@@ -88,6 +88,7 @@ export class ConcatMp4sFlow extends Flow {
       let videoAeosDroped = false;
 
       function attemptDrainVideoBFifo() {
+
         if (videoAeosDroped && videoBeosReceived) {
 
           durationA = Math.max(payloadDescrAudioA ? payloadDescrAudioA.details.sequenceDurationInSeconds : 0,
@@ -107,6 +108,7 @@ export class ConcatMp4sFlow extends Flow {
 
           fifoVideoB.drain();
         }
+
       }
 
       mp4DemuxA.on(ProcessorEvent.OUTPUT_SOCKET_CREATED, (data: ProcessorEventData) => {
@@ -213,7 +215,7 @@ export class ConcatMp4sFlow extends Flow {
 
             if (!payloadDescrAudioB) {
               payloadDescrAudioB = fifoAudioB.queue.peek().defaultPayloadInfo;
-              log('got primary audio payload description:', payloadDescrAudioB)
+              log('got secondary audio payload description:', payloadDescrAudioB)
             }
 
           });
@@ -224,7 +226,8 @@ export class ConcatMp4sFlow extends Flow {
       xhrSocketMovA.connect(mp4DemuxA.in[0])
       xhrSocketMovB.connect(mp4DemuxB.in[0])
 
-      mp4Muxer.out[0].connect(new WebFileDownloadSocket(null, 'video/mp4', makeTemplate('buffer${counter}-${Date.now()}.mp4')))
+      mp4Muxer.out[0].connect(
+        new WebFileDownloadSocket(null, 'video/mp4', makeTemplate('buffer${counter}-${Date.now()}.mp4')))
 
     }
 

--- a/src/flows/concat-mp4s.flow.ts
+++ b/src/flows/concat-mp4s.flow.ts
@@ -180,6 +180,10 @@ export class ConcatMp4sFlow extends Flow {
 
           fifoVideoB.addPacketFilterPass((p) => {
 
+            if (p.defaultPayloadInfo && p.defaultPayloadInfo.isBitstreamHeader) {
+              log('found secondary payload bitstream header')
+            }
+
             p.timestamp = p.timestamp
               + (p.getTimescale() * durationA)
 

--- a/src/io-sockets/web-file-download.socket.ts
+++ b/src/io-sockets/web-file-download.socket.ts
@@ -20,7 +20,7 @@ export class WebFileDownloadSocket extends InputSocket {
    *
    * @param _downloadLinkContainer an HTML element to create a link in with the given templates or `null` and then FileSaver will spawn a dialog @see https://github.com/eligrey/FileSaver.js
    * @param _fileNameTemplate can contain the local var `counter` as well as access public and private members via `this`, see default
-   * @param _htmlTemplate can contain the local var `filename` which will be whatever the respective template string has eval'd to, see default
+   * @param _htmlTemplate can contain the local var `filename` which will be whatever the respective template string has eval'd to, see default for example (or like `makeTemplate('buffer${counter}-${Date.now()}.mp4'`)
    * @param _mimeType mime-type string for the blob object to be created (this sometimes matters for platforms to understand what file-type it is), @see https://developer.mozilla.org/en-US/docs/Web/API/Blob
    * @param _fallbackToSaveAs when no downloadLinkContainer set, we can call the `saveAs` function to trigger a download dialog (if running in a web-like window context)
    */

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -9,6 +9,7 @@ describe('Logger', () => {
   beforeEach(() => {
     global.console = Object.assign(global.console, {
       debug: jest.fn(),
+      warn: jest.fn(),
       error: jest.fn()
     })
   })
@@ -181,30 +182,59 @@ describe('Logger', () => {
     it('should use the default log level', () => {
       logger.debug('foo');
       logger.error('bar');
+      logger.warn('foobar');
       (global.console.debug as jest.Mock).mock.calls.length.should.be.equal(0);
+      (global.console.warn as jest.Mock).mock.calls.length.should.be.equal(1);
       (global.console.error as jest.Mock).mock.calls.length.should.be.equal(1);
     });
   })
 
-  describe('overriding a logger with a default level', () => {
+  describe('overriding the default level of a category with the wildcard config ', () => {
     let logger: Logger
 
     beforeEach(() => {
       (global as any).localStorage = {
         getItem () {
-          return '{"*": 5}'
+          return '{"*": 2}'
         },
         setItem () {
         }
       }
-      logger = getLogger('CategoryWithDefaultLevel', LoggerLevel.WARN)
+      logger = getLogger('CategoryWithDefaultLevel', LoggerLevel.ON)
     })
 
-    it('should use the logger-default log level', () => {
+    it('should use the level specified by user configuration (not the default)', () => {
       logger.debug('foo');
+      logger.warn('foobar');
       logger.error('bar');
-      (global.console.debug as jest.Mock).mock.calls.length.should.be.equal(1);
+      (global.console.debug as jest.Mock).mock.calls.length.should.be.equal(0);
+      (global.console.warn as jest.Mock).mock.calls.length.should.be.equal(1);
       (global.console.error as jest.Mock).mock.calls.length.should.be.equal(1);
     });
   })
+
+  describe('overriding the default level of a category with the wildcard config disabling all logging', () => {
+    let logger: Logger
+
+    beforeEach(() => {
+      (global as any).localStorage = {
+        getItem () {
+          return '{"*": 0}'
+        },
+        setItem () {
+        }
+      }
+      logger = getLogger('CategoryWithDefaultLevel', Infinity)
+    })
+
+    it('should use the level specified by user configuration (not the default), and thus nothing should be logged', () => {
+      logger.debug('foo');
+      logger.warn('foobar');
+      logger.error('bar');
+      (global.console.debug as jest.Mock).mock.calls.length.should.be.equal(0);
+      (global.console.warn as jest.Mock).mock.calls.length.should.be.equal(0);
+      (global.console.error as jest.Mock).mock.calls.length.should.be.equal(0);
+    });
+  })
+
 });

--- a/src/processors/mozilla-rtmpjs/mp4iso-boxes.ts
+++ b/src/processors/mozilla-rtmpjs/mp4iso-boxes.ts
@@ -552,6 +552,7 @@ export type StblSample = {
   dts: number
   cts: number
   isRap: boolean // "random access point" -> appears in sync-samples box
+  sampleDescriptionIndex: number
 }
 
 /**

--- a/src/processors/mozilla-rtmpjs/mp4iso-sample-table.ts
+++ b/src/processors/mozilla-rtmpjs/mp4iso-sample-table.ts
@@ -40,7 +40,7 @@ export class SampleTablePackager {
    * @param chunkOffset
    */
   static createFromSamplesInSingleChunk (
-    sampleDescriptionEntry: Box,
+    sampleDescriptionEntry: Box[],
     samples: StblSample[],
     chunkOffset: number
   ): SampleTableBox {
@@ -167,7 +167,7 @@ export class SampleTablePackager {
     }];
 
     return new SampleTableBox(
-      new SampleDescriptionBox([sampleDescriptionEntry]),
+      new SampleDescriptionBox(sampleDescriptionEntry),
       new DecodingTimeToSampleBox(0, stts),
       new CompositionTimeToSampleBox(0, ctts),
       new SampleToChunkBox(stsc),

--- a/src/processors/mozilla-rtmpjs/mp4iso-sample-table.ts
+++ b/src/processors/mozilla-rtmpjs/mp4iso-sample-table.ts
@@ -37,15 +37,15 @@ export class SampleTablePackager {
    *
    * @param sampleDescriptionEntry
    * @param samples
-   * @param chunkOffset
+   * @param firstChunkOffset
    */
   static createFromSamplesInSingleChunk (
     sampleDescriptionEntry: Box[],
     samples: StblSample[],
-    chunkOffset: number
+    firstChunkOffset: number
   ): SampleTableBox {
     log('creating sample table from samples:',
-      samples, 'at offset:', chunkOffset, 'sample description entry:', sampleDescriptionEntry);
+      samples, 'at offset:', firstChunkOffset, 'sample description entry:', sampleDescriptionEntry);
 
     const stts: DecodingTimeToSampleEntry[] = [];
     const ctts: CompositionTimeToSampleEntry[] = [];
@@ -160,11 +160,34 @@ export class SampleTablePackager {
 
     }
 
-    const stsc: SampleToChunkEntry[] = [{
-      firstChunk: 1,
-      samplesPerChunk: samples.length,
-      sampleDescriptionIndex: 1
-    }];
+    const stsc: SampleToChunkEntry[] = [];
+    const stco: number[] = [];
+
+    let chunkOffset: number = firstChunkOffset;
+
+    sampleDescriptionEntry.forEach((sampleDescriptionBox, index) => {
+
+      const oneBasedIndex = index + 1;
+      const samplesInCodingSequenceChunk = samples.filter((sample) => sample.sampleDescriptionIndex === oneBasedIndex);
+
+      stsc.push({
+        firstChunk: oneBasedIndex,
+        samplesPerChunk: samplesInCodingSequenceChunk.length,
+        sampleDescriptionIndex: oneBasedIndex
+      });
+
+      stco.push(chunkOffset)
+
+      chunkOffset += samplesInCodingSequenceChunk.reduce((accu: number, sample: StblSample) => accu + sample.size, 0)
+
+    })
+
+
+
+
+
+
+
 
     return new SampleTableBox(
       new SampleDescriptionBox(sampleDescriptionEntry),
@@ -172,7 +195,7 @@ export class SampleTablePackager {
       new CompositionTimeToSampleBox(0, ctts),
       new SampleToChunkBox(stsc),
       new SampleSizeBox(stsz),
-      new ChunkOffsetBox([chunkOffset]),
+      new ChunkOffsetBox(stco),
       new SyncSampleBox(stss)
     );
   }

--- a/src/processors/mozilla-rtmpjs/mp4mux.ts
+++ b/src/processors/mozilla-rtmpjs/mp4mux.ts
@@ -517,7 +517,7 @@ export class MP4Mux {
               dts,
               cts: dts,
               isRap: true,
-              sampleDescriptionIndex: 0
+              sampleDescriptionIndex: 1
             };
 
             samples.push(s);
@@ -631,6 +631,7 @@ export class MP4Mux {
           sampleEntry.otherBoxes = [
             new RawTag('esds', esdsData)
           ];
+          sampleDescEntry.push(sampleEntry);
 
           // FIXME: instead of taking the data inside the ES_Descriptor we are using the data contained in esds atom directly
           // i.e the "framed" ES_Descriptor data

--- a/src/processors/mp4-demux.processor.ts
+++ b/src/processors/mp4-demux.processor.ts
@@ -28,14 +28,13 @@ const getSocketDescriptor: SocketTemplateGenerator =
   );
 
 export class MP4DemuxProcessor extends Processor {
-  static getName (): string {
-    return 'MP4DemuxProcessor';
-  }
+
+    static getName (): string {
+      return 'MP4DemuxProcessor';
+    }
 
     private _demuxer: Mp4Demuxer;
-
     private _haveStreamStart: boolean = false;
-
     private _trackIdToOutputs: { [id: number] : OutputSocket} = {};
 
     constructor () {

--- a/src/processors/mp4-demux.processor.ts
+++ b/src/processors/mp4-demux.processor.ts
@@ -49,6 +49,7 @@ export class MP4DemuxProcessor extends Processor {
     }
 
     private _ensureOutputForTrack (track: Track): OutputSocket {
+
       const payloadDescriptor = new PayloadDescriptor(track.mimeType);
       const sd = new SocketDescriptor([
         payloadDescriptor
@@ -119,6 +120,7 @@ export class MP4DemuxProcessor extends Processor {
           let samplesCount: number = 1;
           let constantBitrate: number = NaN;
           let codecData: Uint8Array = null;
+          let codecProfile: number = NaN;
 
           if (track.type === Mp4Track.TYPE_VIDEO) {
             const videoAtom = <VideoAtom> track.getMetadataAtom();
@@ -131,6 +133,8 @@ export class MP4DemuxProcessor extends Processor {
 
             const avcCodecData = avcC.data;
             const spsParsed = avcC.spsParsed[0];
+
+            codecProfile = avcC.profile;
 
             /*
             // we should not rely on this information since it might not be present (it's optional data inside the SPS)
@@ -172,6 +176,7 @@ export class MP4DemuxProcessor extends Processor {
             */
 
           } else if (track.type === Mp4Track.TYPE_AUDIO) {
+
             const audioAtom = <AudioAtom> track.getMetadataAtom();
             sampleDepth = audioAtom.sampleSize;
             numChannels = audioAtom.channelCount;
@@ -216,6 +221,7 @@ export class MP4DemuxProcessor extends Processor {
             protoProps.details.width = track.getResolution()[0];
             protoProps.details.height = track.getResolution()[1];
             protoProps.details.samplesPerFrame = 1;
+            protoProps.details.codecProfile = codecProfile;
             protoProps.codec = 'avc';
           } else if (track.isAudio()) {
             protoProps.details.numChannels = numChannels;

--- a/src/processors/mp4-mux-mozilla.processor.ts
+++ b/src/processors/mp4-mux-mozilla.processor.ts
@@ -191,22 +191,21 @@ export class MP4MuxProcessor extends Processor {
         log('got video bitstream header at:', p.toString());
         this.videoBitstreamHeader_ = bufferSlice;
       } else {
-        debug('video packet:', p.toString());
+        //debug('video packet:', p.toString());
       }
 
       if (bufferSlice.props.isKeyframe) {
         log('got keyframe at:', p.toString());
 
-        /*
-        if (false && this.embedCodecDataOnKeyframes_) {
+        if (this.embedCodecDataOnKeyframes_) {
 
           if (!this.videoBitstreamHeader_) {
             throw new Error('not video bitstream header found to embed')
           }
 
           bufferSlice = bufferSlice.prepend(this.videoBitstreamHeader_, bufferSlice.props);
+
         }
-        */
 
       }
 

--- a/src/processors/mp4-mux-mozilla.processor.ts
+++ b/src/processors/mp4-mux-mozilla.processor.ts
@@ -307,6 +307,7 @@ export class MP4MuxProcessor extends Processor {
     numChannels: number,
     durationSeconds: number,
     language: string = 'und'): MP4Track {
+
     if (isVideoCodec(audioCodec)) {
       throw new Error('Not an audio codec: ' + audioCodec);
     }
@@ -322,7 +323,7 @@ export class MP4MuxProcessor extends Processor {
       samplesize: sampleSize
     };
 
-    log('creating audio track:', audioCodec);
+    log('creating audio track:', audioCodec, audioTrack.duration / audioTrack.timescale, 'secs');
 
     this.mp4Metadata_.audioTrackId = this._getNextTrackId();
     this.mp4Metadata_.tracks.push(audioTrack);
@@ -338,6 +339,7 @@ export class MP4MuxProcessor extends Processor {
     durationSeconds: number,
     timescale: number = framerate
   ): MP4Track {
+
     if (!isVideoCodec(videoCodec)) {
       throw new Error('Not a video codec: ' + videoCodec);
     }
@@ -353,7 +355,7 @@ export class MP4MuxProcessor extends Processor {
       language: 'und'
     };
 
-    log('creating video track:', videoCodec);
+    log('creating video track:', videoCodec, 'duration:', videoTrack.duration / timescale, 'secs');
 
     this.mp4Metadata_.videoTrackId = this._getNextTrackId();
     this.mp4Metadata_.tracks.push(videoTrack);

--- a/test-cases/web/chunk-to-media-source.ts
+++ b/test-cases/web/chunk-to-media-source.ts
@@ -20,7 +20,9 @@ export class ChunkToMediaSource extends MmjsTestCase {
     this._videoEl = document.createElement('video');
     this._videoEl.controls = true;
     this._videoEl.addEventListener('error', () => {
+
       error(this._videoEl.error);
+
     })
 
     this.domMountPoint.appendChild(this._videoEl);
@@ -41,6 +43,7 @@ export class ChunkToMediaSource extends MmjsTestCase {
 
   }
 
+  // TODO: create a generic flow-testbench
   run() {
     this._fmp4ToMediaSource.state = FlowState.WAITING;
     this._fmp4ToMediaSource.state = FlowState.FLOWING;

--- a/test-cases/web/concat-mp4s.ts
+++ b/test-cases/web/concat-mp4s.ts
@@ -9,10 +9,10 @@ export class ConcatMp4s extends MmjsTestCase {
   setup(done: () => void) {
 
     this._flow = new ConcatMp4sFlow(
-      '/test-data/mp4/v-0576p-1400k-libx264.mp4',
-      '/test-data/mp4/v-0576p-1400k-libx264.mp4',
-      true,
-      false
+      '/test-data/mp4/SampleVideo_720x480_10mb.mp4',
+      //'/test-data/video-2018-10-04T18_54_27.577Z.mp4',
+      '/test-data/mp4/SampleVideo_1280x720_5mb.mp4',
+      //'/test-data/mp4/v-0576p-1400k-libx264.mp4',
     );
 
     done();

--- a/test-cases/web/concat-mp4s.ts
+++ b/test-cases/web/concat-mp4s.ts
@@ -1,0 +1,27 @@
+import { MmjsTestCase } from "../mmjs-test-case";
+import { ConcatMp4sFlow } from "../../src/flows/concat-mp4s.flow";
+import { FlowState } from "../../src/core/flow";
+
+export class ConcatMp4s extends MmjsTestCase {
+
+  private _flow: ConcatMp4sFlow = null;
+
+  setup(done: () => void) {
+
+    this._flow = new ConcatMp4sFlow(
+      '/test-data/mp4/v-0576p-1400k-libx264.mp4',
+      '/test-data/mp4/v-0576p-1400k-libx264.mp4',
+      true,
+      false
+    );
+
+    done();
+
+  }
+
+  run() {
+    this._flow.state = FlowState.WAITING;
+    this._flow.state = FlowState.FLOWING;
+  }
+
+}

--- a/test-cases/web/index.html
+++ b/test-cases/web/index.html
@@ -17,13 +17,24 @@
 
     <script src="/vendor/ffmpeg.js/ffmpeg-mp4.js"></script>
 
+    <script type="text/javascript">
+
+      localStorage.setItem('mmjs:LoggerConfig', '{"*": 0}')
+      self["mmjs:LoggerConfig"] = '{"*": 0}'
+
+    </script>
+
     <script src="/dist/MMTestCasesWeb.umd.js"></script>
 
     <script src="load-test-cases.js"></script>
 
     <script>
+
       printTestCases();
 
-      setupTestCase(MMTestCasesWeb.mmjs.Common.Utils.parseOptionsFromQueryString().case || 0);
+      var index = MMTestCasesWeb.mmjs.Common.Utils.parseOptionsFromQueryString().case || 0;
+      setupTestCase(index, function() {
+        runTestCase(index)
+      });
     </script>
 </html>

--- a/test-cases/web/index.ts
+++ b/test-cases/web/index.ts
@@ -3,6 +3,7 @@ import { RemixMovieSoundtrack } from './remix-movie-soundtrack'
 import { TsToMp3 } from './ts-to-mp3'
 import { FFmpegBasic } from './ffmpeg-basic';
 import { FFmpegFlow } from './ffmpeg-flow';
+import { ConcatMp4s } from './concat-mp4s';
 
 import * as mmjs from '../../index';
 
@@ -14,5 +15,6 @@ export {
   RemixMovieSoundtrack,
   TsToMp3,
   FFmpegBasic,
-  FFmpegFlow
+  FFmpegFlow,
+  ConcatMp4s
 }

--- a/test-cases/web/load-test-cases.js
+++ b/test-cases/web/load-test-cases.js
@@ -11,14 +11,14 @@ for (var caseName in MMTestCasesWeb) {
   testCases.push([new TestCase(rootEl), caseName]);
 }
 
-function setupTestCase(i) {
+function setupTestCase(i, done) {
   if (i >= testCases.length) {
     console.error('Bad test-case index:', i);
     window.alert('Query a valid test case please.');
     return;
   }
   console.log('Calling setup for test-case index:', i)
-  testCases[i][0].setup();
+  testCases[i][0].setup(done);
 }
 
 function runTestCase(i) {

--- a/test-cases/web/remix-movie-soundtrack.ts
+++ b/test-cases/web/remix-movie-soundtrack.ts
@@ -86,12 +86,14 @@ export class RemixMovieSoundtrack extends MmjsTestCase {
 
       });
 
-      this._flow.state = FlowState.WAITING;
-      this._flow.state = FlowState.FLOWING;
 
     }
 
+    done();
   }
 
-  run() {}
+  run() {
+    this._flow.state = FlowState.WAITING;
+    this._flow.state = FlowState.FLOWING;
+  }
 }

--- a/test-cases/web/remix-movie-soundtrack.ts
+++ b/test-cases/web/remix-movie-soundtrack.ts
@@ -86,6 +86,8 @@ export class RemixMovieSoundtrack extends MmjsTestCase {
 
       });
 
+      this._flow.state = FlowState.WAITING;
+      this._flow.state = FlowState.FLOWING;
 
     }
 
@@ -93,7 +95,6 @@ export class RemixMovieSoundtrack extends MmjsTestCase {
   }
 
   run() {
-    this._flow.state = FlowState.WAITING;
-    this._flow.state = FlowState.FLOWING;
+
   }
 }


### PR DESCRIPTION
This allows to concatenate two mp4 files without any re-transcoding. Given the player supports tracks with multiple sample description entries.

The flow concatenates two mp4 files (respective default audio and video tracks in each) to one mp4 files.

Each tracks' coding sequence is muxed into a seperate sample chunk in the new file. Each sample chunk references the original sample description data (codec init config). This means the output file contains multiple sample description entries per track.

We could verify these files play in QuickTime and VLC.
